### PR TITLE
Initial view of how Instructor Notes play in

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 This is the outline for an in-person workshop. Each scene represents a series of activities that accomplish a goal and discover new concepts in Chef.
 
-Each scene is a markdown script (scene file). Each scene will have an accompanying slides (etc. pdf, keynote, powerpoint).
+Each scene is a markdown script (scene file). Each scene will have an accompanying slide deck (etc. pdf, keynote, powerpoint).
 
 Each scene is deliverable. Allowing for the development and refinement of scenes while the others may still need the initial script or slides.
 
 Please refer to the [issues](https://github.com/learnchef/chefdk-fundamentals/issues) to figure out what sections could use your attention.
 
-* Write the scene text - If you find a scene text is missing, write an initial outline of the scene. Don't worry someone will come through and clean it up. I promised. Plus it would be fun. You can help shape the words that are said aloud when the training is delivered. What should you used as inspiration? Well if there are slides then use those -- none of those, then well it's fresh snow!
+* Write the scene text - If you find a scene text is missing, write an initial outline of the scene. Don't worry someone will come through and clean it up. I promised. Plus it would be fun. You can help shape the words that are said aloud when the training is delivered. What should you use as inspiration? Well if there are slides then use those -- none of those, well then it's fresh snow!
 
 * Edit the scene text - I promised a few people that you would edit the scenes. They told me there all these delicious spelling errors and grammatical issues spread all over. Oh yeah - there is one more thing, if there are slides then make sure your major soap box moments get captured as slides.
+
+* Writing the speaker notes - If there is more context that could be useful to instructors but it probably doesn't apply to classes universally, add it to the speaker notes.  These notes are useful for providing pre-canned examples of additional context, communicating meta-narrative to other instructors, or other things that might fit into an instructor's guide.  The speaker notes are a deeper dive into things that may not fit neatly the scene text.
 
 * Writing the scene slides - If the slides aren't there then welcome to exciting world of Powerpoint. Hey if you don't have Powerpoint but have a great idea for slides -- do it anyways, because great content is great content.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,6 @@
+name              'chefdk-fundamentals'
+maintainer        'Chef Software, Inc.'
+maintainer_email  'training@chef.io'
+license           'Proprietary - All Rights Reserved'
+description       'ChefDK Fundamentals Workshop: Full content repository'
+version           '3.0.0-alpha'

--- a/scene_01.md
+++ b/scene_01.md
@@ -1,0 +1,23 @@
+## Chef Fundamentals Introduction
+
+Welcome your class to Chef Fundamentals Day 1.  We'll be focusing on using Chef through everything that's available in the Chef Development Kit (chefdk).
+
+Introduce yourself.  Tell students your name, your current job role at Chef, a brief summary of your previous job roles/background, a recap of your experience with Chef/config management/automation, and a fun personal factoid.
+
+Have your students introduce themselves.
+
+We set expectations for the course by covering our anticipated outcomes, agenda, and interaction styles.
+
+Our expected outcome from the Chef Fundamentals coursework is that students will emerge with a basic understanding of Chef's core components, basic architecture, commonly used tools, and basic troubleshooting methods.  This should be enough core material to start using Chef to automate common infrastructure tasks and express solutions to common infrastructure problems.
+
+Chef is not, in itself, a solution to your infrastructure problems.  Chef is an automation framework.  Students bring the domain expertise about their own unique businesses and problems.  Chef provides a platform for modeling solutions to those problems.  Our job in this class is to work together to teach you how to express solutions to your unique problems with Chef.  Together we get unicorns and rainbows, but we can't have one without the other.
+
+Chef is essentially a programming language for infrastructure.  As such, learning Chef is like learning any language: the best way to learn Chef is to use Chef.  The more you use it, the better your Chef.  The less you use it, the more likely it is you'll forget how to use Chef.  Our job in this class is to get you to reach basic fluency fast.  But the rest comes with continued use and practice.
+
+This class is just a "taste" of using Chef.  We will focus on core Chef concepts to help you reach fluency fast.  We will not have time to explore the entire Chef ecosystem.  Any discussion topics beyond core concepts will be captured and explored as time permits.
+
+However, you should feel free to Ask Me Anything.  This training is really a discussion.  Like most frameworks, applying real world context to Chef helps us learn Chef and reach fluency faster.  We are all here with unique experiences and from unique teams that are using Chef in unique ways.  It is important that we help give you the tools to derive your own answers about how to best use Chef.  This is why we typically say, "what questions can I help you answer?"  If we stray too far off topic, we will capture your questions and come back to them as time permits.
+
+You should also feel free to ask for help.  This class centers around hands on lab exercises.  Each module builds upon previous concepts and previous exercises.  If you cannot complete an exercise, you will probably not be able to complete the following exercises either.  Ask for help when you need it.  We will troubleshoot and fix bugs on the spot.  In fact, sometimes a bug will be purposefully introduced to illustrate an object lesson.  So if you need help, rejoice!  You're helping the class becomme fluent with Chef when you ask for help.
+
+Lastly, we cover the class agenda (TBD as this repo progresses).

--- a/scene_01_notes.md
+++ b/scene_01_notes.md
@@ -1,0 +1,27 @@
+## Chef Fundamentals Introduction
+
+### Module objectives
+
+The purpose of introductions is to get to know your audience.  Try to assess interests, skill level, and motivation for learning Chef so the instructor can later maintain a consistent level of engagement.
+
+We set expectations because some students may have very little context about what Chef is, what this class will be like, or anything about the next couple of days.  Immediately dispell the notion that Chef is a magic pony.  Chef does not wave a wand and make complexity disappear.  This is why automation should never be seen as threatening by students.  Automators provide value by bringing their expertise to the table and making processes repeatable, testable, and scalable.  Students new to automation may find it threatening.  It's your job to help them see the value of tools like Chef.
+
+We also set expectations to wrangle in students who may have some Chef experience, but are in Fundamentals because they want help with advanced topics.  If the majority of any class would be well served by covering advanced topics, you should absolutely do what's right for that class.  By setting these clear expectations up front, you establish recourse when you encounter scenarios where a majority of the class would not find advanced topics useful.  These expectations work both ways.  Be adamate about them.
+
+### Instructor Tips
+
+We ask students to tell us about their backgrounds so that instructors can look for early signs of which students may fall on either side of the bell curve.  Try assessing things like:
+
+* Is this a developer or operations focused audience?
+* How much of a disparity exists in Chef expertise?
+* Which students have the least technical experience?
+* Which students have the most technical experience that might be able to help those with the least?
+* What is the common theme in backgrounds?
+
+Consider practicing this portion with your own unique voice.  This is a first impression that establishes trust and rapport.  The more comfortable you can make your students feel and the more approachable you seem, the more likely you will have a successful class.
+
+Many instructors find the concept of a question "parking lot" useful.  Use a whiteboard to write down questions that veer off topic in a place where students can see them.  Return to the parking lot as topics become relevant or as time permits.
+
+### Typical Module Pace
+
+20-30 minutes

--- a/scene_02.md
+++ b/scene_02.md
@@ -1,0 +1,9 @@
+## Getting a Workstation
+
+In order to maximize our time on becoming fluent in Chef, we are going to start with pre-configured student workstations.  These workstations have all of our necessary tools installed with classroom customized configurations.  There is nothing special about these workstations other than the fact that they are going to save us time getting started.  Don't worry, we will circle back around and end Day 1 by setting up our own workstations from scratch.
+
+We end today's lesson by having an Install Fest.  During that time we will learn about the underlying tools, setup procedures, and we will have ample time to troubleshoot any installation issues you may experience on your local workstation.
+
+We cover the procedure for accessing remote workstations.
+
+Once everyone is able to access their remote workstations, quickly cover a bullet point list of what's installed on these machines.

--- a/scene_02_notes.md
+++ b/scene_02_notes.md
@@ -1,0 +1,17 @@
+## Getting a Workstation
+
+### Module objectives
+
+Get students ready to see value from using Chef as quickly as possible!
+
+The reason we cover a bullet point list of what's installed is because, inevitably, some of your students will bail during the setup portion at the end of class.  We should at least give them a map of what things they'll need to figure out how to do when they try it later.
+
+### Instructor Tips
+
+We insert tips about using whatever wonky solution we have for students to use in this section.
+
+Hopefully it's better than Cloudshare. ;-)
+
+### Typical Module Pace
+
+Some appropriate amount of minutes


### PR DESCRIPTION
This is a hybrid of what I've done with Train the Trainer material.  As discussed during last night's #midnightops session.  This is as much as I could crank out between meetings.

I think this sort of content fills a gap wherein we can hand this entire repo to a new trainer and they can absorb a lot of what they get from shadowing at present.  What instructors who are shadowing should really be doing is practicing what they read in this repo, getting coached time in front of a live audience, and getting an idea of how to apply one's own personal style and ownership to the content.

What they shouldn't be doing is taking notes on all of the stuff we're capturing between the script and the speaker notes.  That's mostly what happens in shadow training today.

Thoughts on making this better?  I'll incorporate feedback for round 3.

Also, purposefully picking content that won't cause merge conflicts.